### PR TITLE
Export types from jsx-runtime.ts

### DIFF
--- a/jsx-runtime.ts
+++ b/jsx-runtime.ts
@@ -1,13 +1,13 @@
 import type { HTMLElements } from "./html.ts";
 import type { CSSProperties } from "./css.ts";
 
-interface RawHtml {
+export interface RawHtml {
   __html?: string;
 }
 
-type Props = Record<string, unknown>;
+export type Props = Record<string, unknown>;
 
-type Content =
+export type Content =
   | string
   | number
   | boolean
@@ -17,7 +17,7 @@ type Content =
 
 const ssxElement = Symbol.for("ssx.element");
 
-interface Component {
+export interface Component {
   // deno-lint-ignore no-explicit-any
   type: string | ((props: Props) => any);
   props: Props;


### PR DESCRIPTION
The types are needed for JSX to be used outside of Lume. Is `renderComponent` the correct way to render components?

Example code:

```ts
import { renderComponent, type Component } from "lume/jsx-runtime";

const page = async (children: Component) => {
return `
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>LetsCuddle</title>
</head>
<body>
    ${await renderComponent(children)}
</body>
</html>
`;
};

export const index = (entityCount: number) => page(
    <>
        <section>
            <h1><img src="/favicon.png" alt="blaha" width="40" /> LetsCuddle</h1>
            <p>Cuddles for every body</p>
            <p><del>A nonprofit</del> organizing free cuddles to {entityCount} entities.</p>
            <a href="#setup">Get Started</a>
        </section>
        <section id="setup">
            <h2>Getting started</h2>
        </section>
    </>
);
```